### PR TITLE
Set sumo vehicle id to corresponding carla vehicle role name

### DIFF
--- a/co-simulation/bridge/carla_integration/bridge_helper.py
+++ b/co-simulation/bridge/carla_integration/bridge_helper.py
@@ -111,7 +111,7 @@ class BridgeHelper(object):
         return random.choice(blueprints)
 
     @staticmethod
-    def get_carla_blueprint(sumo_actor, sync_color=False):
+    def get_carla_blueprint(sumo_actor, sumo_id, sync_color=False):
         """
         Returns an appropriate blueprint based on the received sumo actor.
         """
@@ -144,7 +144,7 @@ class BridgeHelper(object):
             driver_id = random.choice(blueprint.get_attribute('driver_id').recommended_values)
             blueprint.set_attribute('driver_id', driver_id)
 
-        blueprint.set_attribute('role_name', 'sumo_driver')
+        blueprint.set_attribute('role_name', sumo_id)
 
         logging.debug(
             '''[BridgeHelper] sumo vtype %s will be spawned in carla with the following attributes:

--- a/co-simulation/bridge/carla_integration/synchronization.py
+++ b/co-simulation/bridge/carla_integration/synchronization.py
@@ -99,7 +99,7 @@ class SimulationSynchronization(object):
         sumo_spawned_actors = self.sumo.spawned_actors - set(self.carla2sumo_ids.values())
         for sumo_actor_id in sumo_spawned_actors:
             sumo_actor = self.sumo.get_actor(sumo_actor_id)
-            carla_blueprint = BridgeHelper.get_carla_blueprint(sumo_actor, self.sync_vehicle_color)
+            carla_blueprint = BridgeHelper.get_carla_blueprint(sumo_actor, sumo_actor_id, self.sync_vehicle_color)
             if carla_blueprint is not None:
                 carla_transform = BridgeHelper.get_carla_transform(sumo_actor.transform,
                                                                    sumo_actor.extent)


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

The current CDASim can synchronize vehicle positions and orientations between Carla and SUMO simulations. However, there's an issue with the correct synchronization of SUMO IDs and Carla role names. This PR aims to address and fix this problem.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.