### PR TITLE
Added configuration files for sumo GUI settings

### DIFF
--- a/co-simulation/bundle/src/assembly/resources/scenarios/Town04/sumo/Town04.sumocfg
+++ b/co-simulation/bundle/src/assembly/resources/scenarios/Town04/sumo/Town04.sumocfg
@@ -7,6 +7,8 @@
         <net-file value="Town04.net.xml"/>
         <route-files value="Town04.rou.xml"/>
         <additional-files value="detector.xml"/>
+        <gui-settings-file value="gui.settings.xml"/>
+
     </input>
     <gui_only>
         <tracker-interval value="0.1"/>

--- a/co-simulation/bundle/src/assembly/resources/scenarios/Town04/sumo/gui.settings.xml
+++ b/co-simulation/bundle/src/assembly/resources/scenarios/Town04/sumo/gui.settings.xml
@@ -1,0 +1,4 @@
+<viewsettings>
+    <!-- <viewport y="0" x="250" zoom="100"/> -->
+    <delay value="1000"/>
+</viewsettings>


### PR DESCRIPTION
Set Delay to 1000 ms per second to startup SUMO running at approximately real-time to avoid time sync issues with simulation and infrastructure

<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

<!--- Describe your changes in detail -->
Due to this issue (https://github.com/usdot-fhwa-OPS/V2X-Hub/issues/540) the current time synchronization between infrastructure (V2X-Hub) and CDASim is non-time regulating, meaning Infrastructure does not currently have a way of notifying CDASim when it is ready for time to advance in simulation. Due to this, is simulation is running faster than real time, Infrastructure can begin to fall behind. To avoid this, this PR adds a GUI settings file to the SUMO GUI, which is used to play/pause/step through the simulation. In this settings file, we can configure the delay, a sumo GUI feature that controls how long, if at all, between time steps SUMO will wait before inform proceeding to the next time. Since SUMO's integration with CDASim is time regulating, this delay feature allow a use to modify the maximum speed at which the simulation can run. The new settings file configures this value to be 1000ms per 1s (~ real-time) at startup to avoid the need for manual configuration at start up
## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Avoid (https://github.com/usdot-fhwa-OPS/V2X-Hub/issues/540)
## How Has This Been Tested?
XIL-Cloud deployment
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](Contributing.md) 
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.