### PR TITLE
Fix null pointer when infrastructure registration includes no sensor registrations

### DIFF
--- a/co-simulation/fed/mosaic-infrastructure/src/main/java/org/eclipse/mosaic/fed/infrastructure/ambassador/InfrastructureMessageAmbassador.java
+++ b/co-simulation/fed/mosaic-infrastructure/src/main/java/org/eclipse/mosaic/fed/infrastructure/ambassador/InfrastructureMessageAmbassador.java
@@ -309,12 +309,13 @@ public class InfrastructureMessageAmbassador extends AbstractFederateAmbassador 
                 // Check for empty list of sensors which is valid
                 if (reg.getSensors() != null ) {
                     log.debug("Sending SensorRegistration interactions for sensor : {}", reg.getSensors());
-                } 
-                else {
                     for (Detector sensor : reg.getSensors()) {
                         // Trigger Sensor registrations for all listed sensors.
                         this.rti.triggerInteraction(new DetectorRegistration(time,sensor));
                     }
+                } 
+                else {
+                   log.warn("No sensors registered for infrastructure instance {}.", reg.getInfrastructureId());
                 }
             }
 

--- a/co-simulation/fed/mosaic-infrastructure/src/main/java/org/eclipse/mosaic/fed/infrastructure/ambassador/InfrastructureMessageAmbassador.java
+++ b/co-simulation/fed/mosaic-infrastructure/src/main/java/org/eclipse/mosaic/fed/infrastructure/ambassador/InfrastructureMessageAmbassador.java
@@ -295,20 +295,26 @@ public class InfrastructureMessageAmbassador extends AbstractFederateAmbassador 
             List<InfrastructureRegistrationMessage> newRegistrations = infrastructureRegistrationReceiver
                     .getReceivedMessages();
             for (InfrastructureRegistrationMessage reg : newRegistrations) {
-                log.info("Processing new registration request for " + reg.getInfrastructureId());
+                log.info("Processing new registration request for  {}.", reg.getInfrastructureId());
                 // Store new instance registration to infrastructure instance manager
                 infrastructureInstanceManager.onNewRegistration(reg);
                 // Process registration requests for RSUs and DSRCs
                 onRsuRegistrationRequest(reg.getInfrastructureId(), reg.getLocation().toGeo());
-                log.info("RSU Registration for "+ reg.getInfrastructureId() + " @ x, y, z: (" + reg.getLocation().getX() + ", " + reg.getLocation().getY() + ", " + reg.getLocation().getZ() + ")");
+                log.info("RSU Registration for {} @ x, y, z: ( {}, {}, {}) .", 
+                                            reg.getInfrastructureId(),
+                                            reg.getLocation().getX(),
+                                            reg.getLocation().getY(), 
+                                            reg.getLocation().getZ());
                 onDsrcRegistrationRequest(reg.getInfrastructureId());
                 // Check for empty list of sensors which is valid
                 if (reg.getSensors() != null ) {
                     log.debug("Sending SensorRegistration interactions for sensor : {}", reg.getSensors());
-                }
-                for (Detector sensor : reg.getSensors()) {
-                    // Trigger Sensor registrations for all listed sensors.
-                    this.rti.triggerInteraction(new DetectorRegistration(time,sensor));
+                } 
+                else {
+                    for (Detector sensor : reg.getSensors()) {
+                        // Trigger Sensor registrations for all listed sensors.
+                        this.rti.triggerInteraction(new DetectorRegistration(time,sensor));
+                    }
                 }
             }
 


### PR DESCRIPTION

<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
InfrastructureMessageAmbassador throws nullpointer exception when infrastructure registration message includes no sensor registrations. This PR addresses that and addresses some sonar code smells about logger calls
<!--- Describe your changes in detail -->
## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Fix null pointer
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](Contributing.md) 
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.