### PR TITLE
Add example ScenarioRunner configurations

### DIFF
--- a/scenario-runner/README.md
+++ b/scenario-runner/README.md
@@ -1,5 +1,7 @@
 # CARLA ScenarioRunner scenarios
 
-This directory contains custom ScenarioRunner scenario configurations to
-facilitate integration testing. This still a work in progress, so the scenarios
-serve more as example references.
+This directory contains custom [ScenarioRunner][scenario_runner_docs_link]
+scenario configurations to facilitate integration testing. This still a work in
+progress, so the scenarios serve more as example references.
+
+[scenario_runner_docs_link]: https://carla-scenariorunner.readthedocs.io/en/latest/

--- a/scenario-runner/README.md
+++ b/scenario-runner/README.md
@@ -1,0 +1,5 @@
+# CARLA ScenarioRunner scenarios
+
+This directory contains custom ScenarioRunner scenario configurations to
+facilitate integration testing. This still a work in progress, so the scenarios
+serve more as example references.

--- a/scenario-runner/my_scenario.py
+++ b/scenario-runner/my_scenario.py
@@ -90,7 +90,10 @@ class MyScenario(BasicScenario):
         BasicScenario parent class. The base class's implementation adds
         a trigger that prevents the scenario from starting until the
         ego vehicle drives some distance. We don't want that trigger
-        for this scenario.
+        for this scenario because the ego vehicle will not move. Override this
+        function to create custom scenario start triggers. Follow this link
+        for more information:
+        https://carla-scenariorunner.readthedocs.io/en/latest/creating_new_scenario/
 
         :return: None
         """
@@ -112,6 +115,9 @@ class MyScenario(BasicScenario):
             crossing_person, 2.0, 8.0, name="walk_across_street"
         )
 
+        # This end condition is commented out because it is not currently being
+        # used in the scenario. It remains here as an example/reference for
+        # how to gracefully end a ScenarioRunner scenario.
         # end_condition = DriveDistance(carma_vehicle, 10)
 
         root = py_trees.composites.Sequence(name="root_sequence")
@@ -130,6 +136,8 @@ class MyScenario(BasicScenario):
         :return: List of test criteria
         """
         return [
+            # This is an example usage for including test criteria in
+            # ScnearioRunner.
             # CollisionTest(self.carma_vehicle)
         ]
 

--- a/scenario-runner/my_scenario.py
+++ b/scenario-runner/my_scenario.py
@@ -1,0 +1,137 @@
+# Copyright 2023 Leidos
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import py_trees
+
+from srunner.scenariomanager.carla_data_provider import CarlaDataProvider
+from srunner.scenariomanager.scenarioatomics.atomic_behaviors import Idle, KeepVelocity
+from srunner.scenariomanager.scenarioatomics.atomic_criteria import CollisionTest
+from srunner.scenariomanager.scenarioatomics.atomic_trigger_conditions import (
+    DriveDistance,
+)
+from srunner.scenarios.basic_scenario import BasicScenario
+from srunner.scenarioconfigs.scenario_configuration import ScenarioConfiguration
+
+
+class MyScenario(BasicScenario):
+    def __init__(
+        self,
+        world,
+        ego_vehicles,
+        config: ScenarioConfiguration,
+        randomize: bool = False,
+        debug_mode: bool = False,
+        criteria_enable: bool = True,
+        timeout=60,
+    ) -> None:
+        """
+        :param world: CARLA world in which the scenario is running
+        :param list[carla.Vehicle] ego_vehicles: CARLA vehicle objects created based on scenario XML configuration
+        :param ScenarioConfiguration config: Specifications from scenario XML configuration
+        :param bool randomize:
+        :param bool debug_mode:
+        :param bool criteria_enable:
+        :param float timeout: Threshold (in seconds) after which test automatically fails
+
+        :return: None
+        :rtype: None
+        """
+        # Must be defined before super() call because BasicScenario
+        # references is in its __init__() function.
+        self.timeout = timeout
+
+        super(MyScenario, self).__init__(
+            "MyScenario",
+            ego_vehicles,
+            config,
+            world,
+            debug_mode=debug_mode,
+            criteria_enable=criteria_enable,
+        )
+
+        self.world_map = CarlaDataProvider.get_map()
+
+        self.carma_vehicle = ego_vehicles[0]
+        self.other_actors_dict = {}
+
+    def _initialize_actors(self, config: ScenarioConfiguration) -> None:
+        """
+        Note: this function overrides the one in BasicScenario (parent
+        class), so this override is responsible for adding the actors
+        defined in the scenario XML configuration.
+
+        :param ScenarioConfiguration config: Specifications from
+        scenario XML configuration
+        :return: None
+        """
+        actors = CarlaDataProvider.request_new_actors(config.other_actors)
+
+        self.other_actors_dict = {
+            actor_config.rolename: actor
+            for actor_config, actor in zip(config.other_actors, actors)
+        }
+
+    def _setup_scenario_trigger(self, _: ScenarioConfiguration) -> None:
+        """
+        Set up the scenario start trigger
+
+        Note: this function overrides the abstract one in the
+        BasicScenario parent class. The base class's implementation adds
+        a trigger that prevents the scenario from starting until the
+        ego vehicle drives some distance. We don't want that trigger
+        for this scenario.
+
+        :return: None
+        """
+        pass
+
+    def _create_behavior(self):
+        """
+        Setup the behavior for NewScenario
+
+        Note: this function overrides the abstract one in the
+        BasicScenario parent class.
+
+        :return: Behavior tree root
+        """
+        start_condition = Idle(5, name="start_condition")
+
+        crossing_person = self.other_actors_dict["crossing_person"]
+        walk_across_street = KeepVelocity(
+            crossing_person, 2.0, 8.0, name="walk_across_street"
+        )
+
+        # end_condition = DriveDistance(carma_vehicle, 10)
+
+        root = py_trees.composites.Sequence(name="root_sequence")
+        root.add_child(start_condition)
+        root.add_child(walk_across_street)
+        # root.add_child(end_condition)
+
+        return root
+
+    def _create_test_criteria(self) -> list:
+        """
+        Setup the evaluation criteria for NewScenario
+
+        Note: this function overrides the one in BasicScenario (parent class).
+
+        :return: List of test criteria
+        """
+        return [
+            # CollisionTest(self.carma_vehicle)
+        ]
+
+    def __del__(self):
+        self.remove_all_actors()

--- a/scenario-runner/my_scenario.xml
+++ b/scenario-runner/my_scenario.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0"?>
+
+<!--
+Copyright 2023 Leidos
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<scenarios>
+    <scenario name="MyScenario_1" type="MyScenario" town="Town04">
+        <ego_vehicle x="203.44" y="-230.0" z="2" yaw="-90.0" model="vehicle.audi.a2" rolename="carma"/>
+
+        <other_actor x="212.68" y="-242.44" z="2" model="vehicle.diamondback.century" rolename="cyclist"/>
+        <other_actor x="214.79" y="-245.61" z="2" model="vehicle.carlamotors.carlacola" rolename="heavy_truck"/>
+        <other_actor x="216.58" y="-248.69" z="2" model="walker.pedestrian.0001" rolename="in_road_person"/>
+        <other_actor x="195.59" y="-254.18" z="2" yaw="90.0" model="walker.pedestrian.0002" rolename="crossing_person"/>
+        <other_actor x="208.58" y="-239.0" z="2" yaw="180.0" model="walker.pedestrian.0003" rolename="corner_person_01"/>
+        <other_actor x="208.58" y="-239.0" z="2" yaw="135.0" model="walker.pedestrian.0004" rolename="corner_person_02"/>
+        <other_actor x="207.88" y="-257.57" z="2" yaw="167.0" model="walker.pedestrian.0005" rolename="corner_person_03"/>
+    </scenario>
+</scenarios>

--- a/scenario-runner/requirements.txt
+++ b/scenario-runner/requirements.txt
@@ -1,0 +1,6 @@
+py_trees
+
+# Note: The `srunner` package in PyPi is outdated, and the ScenarioRunner
+# documentation uses the source-installed `srunner` package in all of its
+# examples.
+# srunner


### PR DESCRIPTION
# PR Details
## Description

This PR adds example CARLA ScenarioRunner configurations that we can use for integration testing with CARMA. These files are intended to be example references rather than concrete test scenarios. More work is necessary to integrate this functionality with CDASim

## Related Issue

Closes #160
[CDAR-334](https://usdot-carma.atlassian.net/browse/CDAR-334)

## Motivation and Context

ScenarioRunner provides an easier way to define and run integration test scenarios within CARLA. Incorporating this functionality into CDASim will greatly help with automating integration tests.

## How Has This Been Tested?

Manually verified the scenario runs as intended.

## Types of changes

- [x] New feature (non-breaking change that adds functionality)

## Checklist:

- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](Contributing.md) 


[CDAR-334]: https://usdot-carma.atlassian.net/browse/CDAR-334?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ