### PR TITLE
initialize sensors list

### DIFF
--- a/co-simulation/fed/mosaic-infrastructure/src/main/java/org/eclipse/mosaic/fed/infrastructure/ambassador/InfrastructureInstance.java
+++ b/co-simulation/fed/mosaic-infrastructure/src/main/java/org/eclipse/mosaic/fed/infrastructure/ambassador/InfrastructureInstance.java
@@ -21,6 +21,8 @@ import java.net.DatagramPacket;
 import java.net.DatagramSocket;
 import java.net.InetAddress;
 import java.util.List;
+import java.util.ArrayList;
+
 
 import org.eclipse.mosaic.lib.geo.CartesianPoint;
 import org.eclipse.mosaic.lib.objects.detector.DetectedObject;
@@ -44,7 +46,7 @@ public class InfrastructureInstance {
     private int simulatedInteractionPort;
     private CartesianPoint location = null;
     private DatagramSocket socket = null;
-    private List<Detector> sensors;
+    private List<Detector> sensors = new ArrayList<>();
 
     /**
      * Constructor for InfrastructureInstance


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

<!--- Describe your changes in detail -->

Sensor list is initialized as an empty array so an exception is not thrown if there is no sensor configuration.
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
## Related Issue
[CDAR-427](https://usdot-carma.atlassian.net/browse/CDAR-427)
## Motivation and Context

 If a sensor configuration file is not available, registration throws a NullPointerException exception causing CDASim to crash. This is not the desired behavior, since there may be times when a sensor config does not exist.

 The solution is to initialize the sensors list as an empty list.
## How Has This Been Tested?
local integration tested
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](Contributing.md) 
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

[CDAR-427]: https://usdot-carma.atlassian.net/browse/CDAR-427?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ