### PR TITLE
Add logic to connect and retry connection for CARLA Ambassador

### DIFF
--- a/co-simulation/fed/mosaic-carla/src/main/java/org/eclipse/mosaic/fed/carla/ambassador/CarlaAmbassador.java
+++ b/co-simulation/fed/mosaic-carla/src/main/java/org/eclipse/mosaic/fed/carla/ambassador/CarlaAmbassador.java
@@ -221,6 +221,10 @@ public class CarlaAmbassador extends AbstractFederateAmbassador {
                 carlaXmlRpcClient = new CarlaXmlRpcClient(xmlRpcServerUrl);
             }
             carlaXmlRpcClient.initialize();
+            boolean connected = carlaXmlRpcClient.connect(carlaConfig.carlaCDASimAdapterConnectionRetryAttempts);
+            if (!connected) {
+                throw new InternalFederateException("Failed to connect to CARLA CDA Sim Adapter with CARLA Ambassador configuration : " + carlaConfig + "!");
+            }
         }
         catch (MalformedURLException m) 
         {
@@ -381,7 +385,6 @@ public class CarlaAmbassador extends AbstractFederateAmbassador {
         }
         catch (XmlRpcException e) {
             log.error("Failed to connect to CARLA Adapter : ", e);
-            carlaXmlRpcClient.closeConnection();
         }
     }
 
@@ -533,7 +536,6 @@ public class CarlaAmbassador extends AbstractFederateAmbassador {
         }
         catch(XmlRpcException e) {
             log.error("Error occurred attempting to create sensor : {}\n{}", interaction.getDetector(), e);
-            carlaXmlRpcClient.closeConnection();
         }
 
     }

--- a/co-simulation/fed/mosaic-carla/src/main/java/org/eclipse/mosaic/fed/carla/ambassador/CarlaAmbassador.java
+++ b/co-simulation/fed/mosaic-carla/src/main/java/org/eclipse/mosaic/fed/carla/ambassador/CarlaAmbassador.java
@@ -524,6 +524,7 @@ public class CarlaAmbassador extends AbstractFederateAmbassador {
     /**
      * Method to call XMLRPC method to create sensor on reception of DetectionRegistration interactions. 
      * @param interaction Interaction triggered by Ambassadors attempting to create sensors in CARLA.
+     * @throws InterruptedException
      */
     private void receiveInteraction(DetectorRegistration interaction) {
         try {

--- a/co-simulation/fed/mosaic-carla/src/main/java/org/eclipse/mosaic/fed/carla/ambassador/CarlaAmbassador.java
+++ b/co-simulation/fed/mosaic-carla/src/main/java/org/eclipse/mosaic/fed/carla/ambassador/CarlaAmbassador.java
@@ -213,6 +213,8 @@ public class CarlaAmbassador extends AbstractFederateAmbassador {
             log.error("Error during advanceTime request", e);
             throw new InternalFederateException(e);
         }
+        // Start the CARLA simulator
+        startCarlaLocal();
         //initialize CarlaXmlRpcClient
         //set the connected server URL
         try{
@@ -220,19 +222,19 @@ public class CarlaAmbassador extends AbstractFederateAmbassador {
                 URL xmlRpcServerUrl = new URL(carlaConfig.carlaCDASimAdapterUrl);
                 carlaXmlRpcClient = new CarlaXmlRpcClient(xmlRpcServerUrl);
             }
-            carlaXmlRpcClient.initialize();
-            boolean connected = carlaXmlRpcClient.connect(carlaConfig.carlaCDASimAdapterConnectionRetryAttempts);
-            if (!connected) {
-                throw new InternalFederateException("Failed to connect to CARLA CDA Sim Adapter with CARLA Ambassador configuration : " + carlaConfig + "!");
-            }
+            carlaXmlRpcClient.connect(60);
+            
         }
         catch (MalformedURLException m) 
         {
-            log.error("Errors occurred with {}", m.getMessage());
+            throw new InternalFederateException("Carla Ambassador initialization failed due to CARLA CDA Sim Adapter" 
+                + "connection! Check carla_config.json!", m);
         }
-        // Start the CARLA simulator
-        startCarlaLocal();
-
+        catch (XmlRpcException e ) {
+            throw new InternalFederateException("Carla Ambassador initialization failed due to CARLA CDA Sim "
+                + "Adapter connection! Check carla_config.json!", e);
+        }
+        
     }
 
     /**

--- a/co-simulation/fed/mosaic-carla/src/main/java/org/eclipse/mosaic/fed/carla/ambassador/CarlaAmbassador.java
+++ b/co-simulation/fed/mosaic-carla/src/main/java/org/eclipse/mosaic/fed/carla/ambassador/CarlaAmbassador.java
@@ -234,6 +234,10 @@ public class CarlaAmbassador extends AbstractFederateAmbassador {
             throw new InternalFederateException("Carla Ambassador initialization failed due to CARLA CDA Sim "
                 + "Adapter connection! Check carla_config.json!", e);
         }
+        catch (InterruptedException e) {
+            throw new InternalFederateException("Carla Ambassador initialization failed due to CARLA CDA Sim "
+                + "Adapter connection! Check carla_config.json!", e);
+        }
         
     }
 

--- a/co-simulation/fed/mosaic-carla/src/main/java/org/eclipse/mosaic/fed/carla/ambassador/CarlaAmbassador.java
+++ b/co-simulation/fed/mosaic-carla/src/main/java/org/eclipse/mosaic/fed/carla/ambassador/CarlaAmbassador.java
@@ -380,16 +380,17 @@ public class CarlaAmbassador extends AbstractFederateAmbassador {
             for (DetectedObjectInteraction detectionInteraction: detectedObjectInteractions) {
                 this.rti.triggerInteraction(detectionInteraction);
             }
-        } catch (IllegalValueException e) {
-            log.error("Error during advanceTime(" + time + ")", e);
+        } 
+        catch (IllegalValueException e) {
+            log.error("Failed to process advance time grant due to : ", e);
         }
         catch (XmlRpcException e ) {
             throw new InternalFederateException("Failed to process advance time grant due to CARLA CDA Sim "
                         + "Adapter connection! Check carla_config.json!", e);
         }
         catch (InterruptedException e) {
-            throw new InternalFederateException("Failed to process advance time grant due to CARLA CDA Sim "
-                        + "Adapter connection! Check carla_config.json!", e);
+            log.error("Failed to process advance time grant due to failed thread sleep!", e);
+            Thread.currentThread().interrupt();
         }
     }
 
@@ -419,6 +420,7 @@ public class CarlaAmbassador extends AbstractFederateAmbassador {
                 connectionProcess.waitFor(10, TimeUnit.SECONDS);
             } catch (InterruptedException e) {
                 log.warn("Something went wrong when stopping a process", e);
+                Thread.currentThread().interrupt();
             } finally {
                 connectionProcess.destroy();
             }

--- a/co-simulation/fed/mosaic-carla/src/main/java/org/eclipse/mosaic/fed/carla/ambassador/CarlaAmbassador.java
+++ b/co-simulation/fed/mosaic-carla/src/main/java/org/eclipse/mosaic/fed/carla/ambassador/CarlaAmbassador.java
@@ -222,21 +222,12 @@ public class CarlaAmbassador extends AbstractFederateAmbassador {
                 URL xmlRpcServerUrl = new URL(carlaConfig.carlaCDASimAdapterUrl);
                 carlaXmlRpcClient = new CarlaXmlRpcClient(xmlRpcServerUrl);
             }
-            carlaXmlRpcClient.connect(60);
             
         }
         catch (MalformedURLException m) 
         {
             throw new InternalFederateException("Carla Ambassador initialization failed due to CARLA CDA Sim Adapter" 
                 + "connection! Check carla_config.json!", m);
-        }
-        catch (XmlRpcException e ) {
-            throw new InternalFederateException("Carla Ambassador initialization failed due to CARLA CDA Sim "
-                + "Adapter connection! Check carla_config.json!", e);
-        }
-        catch (InterruptedException e) {
-            throw new InternalFederateException("Carla Ambassador initialization failed due to CARLA CDA Sim "
-                + "Adapter connection! Check carla_config.json!", e);
         }
         
     }
@@ -362,7 +353,10 @@ public class CarlaAmbassador extends AbstractFederateAmbassador {
         }
 
         try {
-
+            if ( time == 0 ) {
+                // Try to connect to CARLA CDA Sim Adapter on first timestep
+                carlaXmlRpcClient.connect(60);
+            }
             // if the simulation step received from CARLA, advance CARLA federate local
             // simulation time
             if (isSimulationStep) {
@@ -389,8 +383,13 @@ public class CarlaAmbassador extends AbstractFederateAmbassador {
         } catch (IllegalValueException e) {
             log.error("Error during advanceTime(" + time + ")", e);
         }
-        catch (XmlRpcException e) {
-            log.error("Failed to connect to CARLA Adapter : ", e);
+        catch (XmlRpcException e ) {
+            throw new InternalFederateException("Failed to process advance time grant due to CARLA CDA Sim "
+                        + "Adapter connection! Check carla_config.json!", e);
+        }
+        catch (InterruptedException e) {
+            throw new InternalFederateException("Failed to process advance time grant due to CARLA CDA Sim "
+                        + "Adapter connection! Check carla_config.json!", e);
         }
     }
 

--- a/co-simulation/fed/mosaic-carla/src/main/java/org/eclipse/mosaic/fed/carla/carlaconnect/CarlaXmlRpcClient.java
+++ b/co-simulation/fed/mosaic-carla/src/main/java/org/eclipse/mosaic/fed/carla/carlaconnect/CarlaXmlRpcClient.java
@@ -40,21 +40,10 @@ public class CarlaXmlRpcClient{
     private static final String CONNECT ="connect";
 
     private XmlRpcClient client;
-    private URL xmlRpcServerUrl;
     private final Logger log = LoggerFactory.getLogger(this.getClass());
 
 
     public CarlaXmlRpcClient(URL xmlRpcServerUrl) {
-        this.xmlRpcServerUrl = xmlRpcServerUrl;
-    }
-
-
-    /**
-     * Initialize XmlRpcClient.
-     * @param xmlRpcServerUrl
-     */
-    public void initialize()
-    {
         XmlRpcClientConfigImpl config = new XmlRpcClientConfigImpl();   
         config.setServerURL(xmlRpcServerUrl);
         // Set reply and connection timeout (both in ms)
@@ -64,7 +53,8 @@ public class CarlaXmlRpcClient{
         client.setConfig(config);
     }
 
-    public boolean connect(int retryAttempts) {
+
+    public void connect(int retryAttempts) throws XmlRpcException{
         boolean connected = false;
         while( !connected && retryAttempts > 0 ) {
             try {
@@ -78,7 +68,10 @@ public class CarlaXmlRpcClient{
                 retryAttempts--;
             }
         } 
-        return connected; 
+        if (!connected) {
+            throw new XmlRpcException("Failed to connect to XML RPC Server with config " + client.getConfig() + " !");
+        }
+        log.info("Connected successfully to CARLA CDA Sim Adapter!");    
     }
     /**
      * Calls CARLA CDA Sim Adapter create_sensor XMLRPC method and logs sensor ID of created sensor.

--- a/co-simulation/fed/mosaic-carla/src/main/java/org/eclipse/mosaic/fed/carla/carlaconnect/CarlaXmlRpcClient.java
+++ b/co-simulation/fed/mosaic-carla/src/main/java/org/eclipse/mosaic/fed/carla/carlaconnect/CarlaXmlRpcClient.java
@@ -54,9 +54,10 @@ public class CarlaXmlRpcClient{
     }
 
 
-    public void connect(int retryAttempts) throws XmlRpcException{
+    public void connect(int retryAttempts) throws XmlRpcException, InterruptedException{
         boolean connected = false;
-        while( !connected && retryAttempts > 0 ) {
+        int currentAttempt = 1;
+        while( !connected && retryAttempts >= currentAttempt ) {
             try {
                 log.info("Attempting to connect to CARLA CDA Sim Adapter ... ");
                 Object[] params = new Object[]{};
@@ -64,8 +65,10 @@ public class CarlaXmlRpcClient{
                 connected = true;
             }
             catch(XmlRpcException e) {
-                log.error("Connection attempt {} to connect to CARLA CDA Sim Adapter failed : {}", retryAttempts, e);
-                retryAttempts--;
+                log.error("Connection attempt {} to connect to CARLA CDA Sim Adapter failed!", currentAttempt, e);
+                // Sleep for 1 second betweeen attempts
+                Thread.sleep(1000);
+                currentAttempt++;
             }
         } 
         if (!connected) {

--- a/co-simulation/fed/mosaic-carla/src/main/java/org/eclipse/mosaic/fed/carla/config/CarlaConfiguration.java
+++ b/co-simulation/fed/mosaic-carla/src/main/java/org/eclipse/mosaic/fed/carla/config/CarlaConfiguration.java
@@ -52,6 +52,11 @@ public class CarlaConfiguration implements Serializable {
      * URL where CARLACDASimAdapter XMLRPC Server is hosted
      */
     public String carlaCDASimAdapterUrl;
+    /**
+     * Number of times Ambassador will retry failing XMLRPC Server connection.
+     */
+    public int carlaCDASimAdapterConnectionRetryAttempts;
+
 
 
 }

--- a/co-simulation/fed/mosaic-carla/src/main/java/org/eclipse/mosaic/fed/carla/config/CarlaConfiguration.java
+++ b/co-simulation/fed/mosaic-carla/src/main/java/org/eclipse/mosaic/fed/carla/config/CarlaConfiguration.java
@@ -52,10 +52,6 @@ public class CarlaConfiguration implements Serializable {
      * URL where CARLACDASimAdapter XMLRPC Server is hosted
      */
     public String carlaCDASimAdapterUrl;
-    /**
-     * Number of times Ambassador will retry failing XMLRPC Server connection.
-     */
-    public int carlaCDASimAdapterConnectionRetryAttempts;
 
 
 

--- a/co-simulation/fed/mosaic-carla/src/test/java/org/eclipse/mosaic/fed/carla/ambassador/CarlaAmbassadorTest.java
+++ b/co-simulation/fed/mosaic-carla/src/test/java/org/eclipse/mosaic/fed/carla/ambassador/CarlaAmbassadorTest.java
@@ -213,8 +213,6 @@ public class CarlaAmbassadorTest {
         ambassador.processInteraction(registration);
 
         verify(carlaXmlRpcClientMock, times(1)).createSensor(registration);
-
-
     }
 
 

--- a/co-simulation/fed/mosaic-carla/src/test/java/org/eclipse/mosaic/fed/carla/ambassador/CarlaAmbassadorTest.java
+++ b/co-simulation/fed/mosaic-carla/src/test/java/org/eclipse/mosaic/fed/carla/ambassador/CarlaAmbassadorTest.java
@@ -44,6 +44,7 @@ import org.junit.rules.RuleChain;
 import org.junit.rules.TemporaryFolder;
 import org.mockito.internal.util.reflection.FieldSetter;
 
+import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
@@ -115,7 +116,8 @@ public class CarlaAmbassadorTest {
         ambassador.initialize(0, 100 * TIME.SECOND);
         // ASSERT
         verify(rtiMock, times(1)).requestAdvanceTime(eq(0L), eq(0L), eq((byte) 1));
-        verify(carlaXmlRpcClientMock, times(1)).connect(60);
+        
+
     }
 
     @Test
@@ -179,7 +181,12 @@ public class CarlaAmbassadorTest {
         
         when(carlaXmlRpcClientMock.getDetectedObjects(registration.getInfrastructureId(), registration.getDetector().getSensorId() )).thenThrow(XmlRpcException.class);
         // Verify that when exceptiopn is thrown by CarlaXmlRpcClient, no interactions are trigger and exception is caught
-        ambassador.processTimeAdvanceGrant(100);
+        try {
+            ambassador.processTimeAdvanceGrant(100);
+        }catch (Exception e) {
+            assertEquals(InternalFederateException.class, e.getClass());
+            assertEquals(XmlRpcException.class, e.getCause().getClass());
+        }
 
         verify(carlaXmlRpcClientMock, times(1)).getDetectedObjects(registration.getInfrastructureId(), registration.getDetector().getSensorId());
         verify(rtiMock, times(0)).triggerInteraction(any(DetectedObjectInteraction.class));

--- a/co-simulation/fed/mosaic-carla/src/test/java/org/eclipse/mosaic/fed/carla/ambassador/CarlaAmbassadorTest.java
+++ b/co-simulation/fed/mosaic-carla/src/test/java/org/eclipse/mosaic/fed/carla/ambassador/CarlaAmbassadorTest.java
@@ -183,7 +183,6 @@ public class CarlaAmbassadorTest {
 
         verify(carlaXmlRpcClientMock, times(1)).getDetectedObjects(registration.getInfrastructureId(), registration.getDetector().getSensorId());
         verify(rtiMock, times(0)).triggerInteraction(any(DetectedObjectInteraction.class));
-        verify(carlaXmlRpcClientMock, times(1)).closeConnection();
 
     }
 
@@ -207,7 +206,6 @@ public class CarlaAmbassadorTest {
         ambassador.processInteraction(registration);
 
         verify(carlaXmlRpcClientMock, times(1)).createSensor(registration);
-        verify(carlaXmlRpcClientMock, times(1)).closeConnection();
 
 
     }

--- a/co-simulation/fed/mosaic-carla/src/test/java/org/eclipse/mosaic/fed/carla/ambassador/CarlaAmbassadorTest.java
+++ b/co-simulation/fed/mosaic-carla/src/test/java/org/eclipse/mosaic/fed/carla/ambassador/CarlaAmbassadorTest.java
@@ -115,7 +115,7 @@ public class CarlaAmbassadorTest {
         ambassador.initialize(0, 100 * TIME.SECOND);
         // ASSERT
         verify(rtiMock, times(1)).requestAdvanceTime(eq(0L), eq(0L), eq((byte) 1));
-        verify(carlaXmlRpcClientMock, times(1)).initialize();
+        verify(carlaXmlRpcClientMock, times(1)).connect(60);
     }
 
     @Test

--- a/co-simulation/fed/mosaic-carla/src/test/java/org/eclipse/mosaic/fed/carla/ambassador/CarlaAmbassadorTest.java
+++ b/co-simulation/fed/mosaic-carla/src/test/java/org/eclipse/mosaic/fed/carla/ambassador/CarlaAmbassadorTest.java
@@ -182,7 +182,7 @@ public class CarlaAmbassadorTest {
         when(carlaXmlRpcClientMock.getDetectedObjects(registration.getInfrastructureId(), registration.getDetector().getSensorId() )).thenThrow(XmlRpcException.class);
         // Verify that when exceptiopn is thrown by CarlaXmlRpcClient, no interactions are trigger and exception is caught
         try {
-            ambassador.processTimeAdvanceGrant(100);
+            ambassador.processTimeAdvanceGrant(0);
         }catch (Exception e) {
             assertEquals(InternalFederateException.class, e.getClass());
             assertEquals(XmlRpcException.class, e.getCause().getClass());

--- a/co-simulation/fed/mosaic-carla/src/test/java/org/eclipse/mosaic/fed/carla/carlaconnect/CarlaXmlRpcClientTest.java
+++ b/co-simulation/fed/mosaic-carla/src/test/java/org/eclipse/mosaic/fed/carla/carlaconnect/CarlaXmlRpcClientTest.java
@@ -2,6 +2,8 @@ package org.eclipse.mosaic.fed.carla.carlaconnect;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -204,31 +206,26 @@ public class CarlaXmlRpcClientTest {
          // Create Detector Registration
         Detector detector = new Detector("sensorID1", DetectorType.SEMANTIC_LIDAR, new Orientation( 0.0,0.0,0.0), CartesianPoint.ORIGO);
         DetectorRegistration registration = new DetectorRegistration(0, detector, "rsu_2");
-        List<Double> location = Arrays.asList(registration.getDetector().getLocation().getX(), registration.getDetector().getLocation().getY(), registration.getDetector().getLocation().getZ());
-        List<Double> orientation = Arrays.asList(registration.getDetector().getOrientation().getPitch(), registration.getDetector().getOrientation().getRoll(), registration.getDetector().getOrientation().getYaw());
-        Object[] params = new Object[]{registration.getInfrastructureId(), registration.getDetector().getSensorId(), location, orientation};
         // Tell mock to return sensor ID when following method is called with following parameters
-        when( mockClient.execute("create_simulated_semantic_lidar_sensor", params)).thenReturn(registration.getSenderId());
-        Object[] get_detected_object_params = new Object[]{registration.getInfrastructureId(), registration.getDetector().getSensorId()};
+        when( mockClient.execute( anyString(), any(Object[].class))).thenThrow(new XmlRpcException(""));
         // Tell mock to return sensor ID when following method is called with following parameters
-        when( mockClient.execute("get_detected_objects", get_detected_object_params)).thenReturn("");
         carlaConnection.closeConnection();
+        assertEquals(false, carlaConnection.isConnected() );
         try {
             carlaConnection.createSensor(registration);
         }
         catch( Exception e ) {
             assertEquals(XmlRpcException.class, e.getClass());
-            assertEquals("XMLRpcClient is not connected to CARLA Adapter!", e.getMessage());
+            assertEquals("XMLRpcClient is not connected to CARLA CDA Sim Adapter after 20 attempts!", e.getMessage());
         }
         try {
             carlaConnection.getDetectedObjects(registration.getInfrastructureId(), registration.getDetector().getSensorId());
         }
         catch( Exception e ) {
             assertEquals(XmlRpcException.class, e.getClass());
-            assertEquals("XMLRpcClient is not connected to CARLA Adapter!", e.getMessage());
+            assertEquals("XMLRpcClient is not connected to CARLA CDA Sim Adapter after 20 attempts!", e.getMessage());
         }
-        // Assert execute is never called on XMLRPC Client after connection is closed.
-        verify( mockClient, times(0)).execute(any(String.class), any(Object[].class));
+        verify( mockClient, times(40)).execute( "connect",new Object[]{});
 
     }
 }

--- a/co-simulation/fed/mosaic-carla/src/test/java/org/eclipse/mosaic/fed/carla/carlaconnect/CarlaXmlRpcClientTest.java
+++ b/co-simulation/fed/mosaic-carla/src/test/java/org/eclipse/mosaic/fed/carla/carlaconnect/CarlaXmlRpcClientTest.java
@@ -209,8 +209,7 @@ public class CarlaXmlRpcClientTest {
         // Tell mock to return sensor ID when following method is called with following parameters
         when( mockClient.execute( anyString(), any(Object[].class))).thenThrow(new XmlRpcException(""));
         // Tell mock to return sensor ID when following method is called with following parameters
-        carlaConnection.closeConnection();
-        assertEquals(false, carlaConnection.isConnected() );
+        assertEquals(false, carlaConnection.connect(10) );
         try {
             carlaConnection.createSensor(registration);
         }

--- a/co-simulation/fed/mosaic-carla/src/test/java/org/eclipse/mosaic/fed/carla/carlaconnect/CarlaXmlRpcClientTest.java
+++ b/co-simulation/fed/mosaic-carla/src/test/java/org/eclipse/mosaic/fed/carla/carlaconnect/CarlaXmlRpcClientTest.java
@@ -1,6 +1,7 @@
 package org.eclipse.mosaic.fed.carla.carlaconnect;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -76,6 +77,20 @@ public class CarlaXmlRpcClientTest {
     public void testConnect() throws XmlRpcException {
         carlaConnection.connect(2);
         verify(mockClient, times(1)).execute( eq("connect"), any(Object[].class));
+    }
+
+    @Test
+    public void testConnectRetry() {
+        try {
+            when(mockClient.execute(eq("connect"), any(Object[].class))).thenThrow(new XmlRpcException(""));
+            carlaConnection.connect(10);
+            verify(mockClient, times(10)).execute( eq("connect"), any(Object[].class));
+        }
+        catch (Exception e) {
+            String message = e.getMessage();
+            assertTrue(message.startsWith("Failed to connect to XML RPC Server with config"));
+            assertEquals(XmlRpcException.class,e.getClass());
+        }
     }
 
     /**

--- a/co-simulation/fed/mosaic-carla/src/test/java/org/eclipse/mosaic/fed/carla/carlaconnect/CarlaXmlRpcClientTest.java
+++ b/co-simulation/fed/mosaic-carla/src/test/java/org/eclipse/mosaic/fed/carla/carlaconnect/CarlaXmlRpcClientTest.java
@@ -74,7 +74,7 @@ public class CarlaXmlRpcClientTest {
         verify( mockClient, times(1)).execute("create_simulated_semantic_lidar_sensor", params);
     }
     @Test
-    public void testConnect() throws XmlRpcException {
+    public void testConnect() throws XmlRpcException, InterruptedException{
         carlaConnection.connect(2);
         verify(mockClient, times(1)).execute( eq("connect"), any(Object[].class));
     }

--- a/co-simulation/fed/mosaic-carla/src/test/java/org/eclipse/mosaic/fed/carla/carlaconnect/CarlaXmlRpcClientTest.java
+++ b/co-simulation/fed/mosaic-carla/src/test/java/org/eclipse/mosaic/fed/carla/carlaconnect/CarlaXmlRpcClientTest.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -41,13 +42,14 @@ public class CarlaXmlRpcClientTest {
      * @throws MalformedURLException
      */
     @Before
-    public void setup() throws NoSuchFieldException, MalformedURLException{
+    public void setup() throws NoSuchFieldException, MalformedURLException, XmlRpcException{
         mockClient = mock(XmlRpcClient.class);
-        URL xmlRpcServerUrl = new URL("http://test_url");
+        URL xmlRpcServerUrl = new URL("http://127.0.0.1:8090/RPC2");
         carlaConnection = new CarlaXmlRpcClient(xmlRpcServerUrl);
-        carlaConnection.initialize();
-        // Set mock after initialize since initialize overwrites member
+        when( mockClient.execute(eq("connect"), any(Object[].class))).thenReturn(true);
         FieldSetter.setField(carlaConnection, carlaConnection.getClass().getDeclaredField("client"), mockClient);
+        
+        // Set mock after initialize since initialize overwrites member
     }
 
     /**
@@ -196,35 +198,4 @@ public class CarlaXmlRpcClientTest {
 
     }
 
-    /**
-     * Test close connection
-     * @throws XmlRpcException
-     */
-    @Test
-    public void testCloseConnection() throws XmlRpcException {
-        // Create request params
-         // Create Detector Registration
-        Detector detector = new Detector("sensorID1", DetectorType.SEMANTIC_LIDAR, new Orientation( 0.0,0.0,0.0), CartesianPoint.ORIGO);
-        DetectorRegistration registration = new DetectorRegistration(0, detector, "rsu_2");
-        // Tell mock to return sensor ID when following method is called with following parameters
-        when( mockClient.execute( anyString(), any(Object[].class))).thenThrow(new XmlRpcException(""));
-        // Tell mock to return sensor ID when following method is called with following parameters
-        assertEquals(false, carlaConnection.connect(10) );
-        try {
-            carlaConnection.createSensor(registration);
-        }
-        catch( Exception e ) {
-            assertEquals(XmlRpcException.class, e.getClass());
-            assertEquals("XMLRpcClient is not connected to CARLA CDA Sim Adapter after 20 attempts!", e.getMessage());
-        }
-        try {
-            carlaConnection.getDetectedObjects(registration.getInfrastructureId(), registration.getDetector().getSensorId());
-        }
-        catch( Exception e ) {
-            assertEquals(XmlRpcException.class, e.getClass());
-            assertEquals("XMLRpcClient is not connected to CARLA CDA Sim Adapter after 20 attempts!", e.getMessage());
-        }
-        verify( mockClient, times(40)).execute( "connect",new Object[]{});
-
-    }
 }

--- a/co-simulation/fed/mosaic-carla/src/test/java/org/eclipse/mosaic/fed/carla/carlaconnect/CarlaXmlRpcClientTest.java
+++ b/co-simulation/fed/mosaic-carla/src/test/java/org/eclipse/mosaic/fed/carla/carlaconnect/CarlaXmlRpcClientTest.java
@@ -72,6 +72,11 @@ public class CarlaXmlRpcClientTest {
         // Verify following method was called on mock
         verify( mockClient, times(1)).execute("create_simulated_semantic_lidar_sensor", params);
     }
+    @Test
+    public void testConnect() throws XmlRpcException {
+        carlaConnection.connect(2);
+        verify(mockClient, times(1)).execute( eq("connect"), any(Object[].class));
+    }
 
     /**
      * Test GetDectedObjects

--- a/co-simulation/fed/mosaic-carla/src/test/resources/carla_config.json
+++ b/co-simulation/fed/mosaic-carla/src/test/resources/carla_config.json
@@ -3,7 +3,5 @@
     "carlaUE4Path": "D:/CARLA_0.9.10/",
     "bridgePath": "./scenarios/Town04_10/carla; bridge.bat",
     "carlaConnectionPort": 8913,
-    "carlaCDASimAdapterUrl":"http://127.0.0.1:8090/RPC2",
-    "carlaCDASimAdapterConnectionRetryAttempts": 20
-
+    "carlaCDASimAdapterUrl":"http://127.0.0.1:8090/RPC2"
 }

--- a/co-simulation/fed/mosaic-carla/src/test/resources/carla_config.json
+++ b/co-simulation/fed/mosaic-carla/src/test/resources/carla_config.json
@@ -3,6 +3,7 @@
     "carlaUE4Path": "D:/CARLA_0.9.10/",
     "bridgePath": "./scenarios/Town04_10/carla; bridge.bat",
     "carlaConnectionPort": 8913,
-    "carlaCDASimAdapterUrl":"http://127.0.0.1:8090/RPC2"
+    "carlaCDASimAdapterUrl":"http://127.0.0.1:8090/RPC2",
+    "carlaCDASimAdapterConnectionRetryAttempts": 20
 
 }


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
Add functionality to CARLA Ambassador to, on initialization, attempt to connect to CARLA CDASim Adapter, with some retry limit. This avoids deployment timing issues that occasionally cause the CARLA Ambassador to drop Sensor Registrations if the CARLA CDA Sim Adapter is not up yet.

**NOTE** This PR requires closing of (https://github.com/usdot-fhwa-stol/carla-sensor-lib/pull/2)
<!--- Describe your changes in detail -->

## Related GitHub Issue

<!--- This project only accepts pull requests related to open GitHub issues or Jira Keys -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please DO NOT name partially fixed issues, instead open an issue specific to this fix -->
<!--- Please link to the issue here: -->

## Related Jira Key
[CDAR-667
](https://usdot-carma.atlassian.net/browse/CDAR-667)<!-- e.g. CAR-123 -->

## Motivation and Context
Improve robustness of deployment by reattempting failing connection on startup, that could fail purely due to CDASim deployment timing issues.
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Sim Computer
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
